### PR TITLE
Allow use on top elements

### DIFF
--- a/src/plugins/vue-columns-resizable/index.js
+++ b/src/plugins/vue-columns-resizable/index.js
@@ -2,8 +2,12 @@ export default {
   install(Vue) {
     Vue.directive('columns-resizable', {
       inserted(el) {
-        const nodeName = el.nodeName;
-        if (['TABLE', 'THEAD'].indexOf(nodeName) < 0) return;
+        let nodeName = el.nodeName;
+        if (['TABLE', 'THEAD'].indexOf(nodeName) < 0) {
+            el = el.querySelector('table'); // looking for the closest table
+            if (!el) return;
+            nodeName = 'TABLE';
+        };
 
         const table = nodeName === 'TABLE' ? el : el.parentElement;
         const thead = table.querySelector('thead');


### PR DESCRIPTION
For example, it is useful for vuetify v-data-table or the same components when we cannot access to `<table>` element